### PR TITLE
Static cache paths for individual caches

### DIFF
--- a/lib/iknow_cache.rb
+++ b/lib/iknow_cache.rb
@@ -18,11 +18,11 @@ class IknowCache
   end
 
   def self.configured?
-    ! config.nil?
+    !config.nil?
   end
 
   def self.configure!(&block)
-    raise ArgumentError.new("Already configured!") if configured?
+    raise ArgumentError.new('Already configured!') if configured?
 
     config = Config.new
     ConfigWriter.new(config).instance_eval(&block)
@@ -240,9 +240,7 @@ class IknowCache
 
       IknowCache.logger.debug("Cache Multi-Read: #{key_paths.values.inspect}") if DEBUG
       raw = IknowCache.cache.read_multi(*key_paths.values)
-      vs = raw.each_with_object({}) do |(path, value), h|
-        h[path_keys[path]] = value
-      end
+      vs = raw.transform_keys { |path| path_keys[path] }
       IknowCache.logger.debug("=> #{vs.inspect}") if DEBUG
       vs
     end

--- a/lib/iknow_cache.rb
+++ b/lib/iknow_cache.rb
@@ -69,8 +69,8 @@ class IknowCache
       group
     end
 
-    def register_cache(name, cache_options: nil)
-      c = Cache.new(self, name, cache_options)
+    def register_cache(name, static_version: nil, cache_options: nil)
+      c = Cache.new(self, name, static_version, cache_options)
       @caches << c
       c
     end
@@ -193,12 +193,13 @@ class IknowCache
   class Cache
     DEBUG = false
 
-    attr_reader :name, :cache_options, :cache_group
+    attr_reader :name, :static_version, :cache_options, :cache_group
 
-    def initialize(cache_group, name, cache_options)
-      @cache_group   = cache_group
-      @name          = name
-      @cache_options = IknowCache.merge_options(cache_group.default_options, cache_options).try { |x| x.dup.freeze }
+    def initialize(cache_group, name, static_version, cache_options)
+      @cache_group    = cache_group
+      @name           = name
+      @static_version = static_version
+      @cache_options  = IknowCache.merge_options(cache_group.default_options, cache_options).try { |x| x.dup.freeze }
     end
 
     def fetch(key, parent_path: nil, **options, &block)
@@ -275,7 +276,9 @@ class IknowCache
     end
 
     def path_string(group_path)
-      "#{group_path}/#{self.name}"
+      path = "#{group_path}/#{self.name}"
+      path = "#{path}/#{self.static_version}" if static_version
+      path
     end
   end
 

--- a/lib/iknow_cache/version.rb
+++ b/lib/iknow_cache/version.rb
@@ -1,3 +1,3 @@
 class IknowCache
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/test/iknow_cache_test.rb
+++ b/test/iknow_cache_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class IknowCache::Test < MiniTest::Test
+class IknowCache::Test < Minitest::Test
   def setup
     IknowCache.cache.clear
     @root = IknowCache::CacheGroup::ROOT_PATH

--- a/test/iknow_cache_test.rb
+++ b/test/iknow_cache_test.rb
@@ -156,6 +156,49 @@ class IknowCache::Test < MiniTest::Test
     assert_equal(data, values)
   end
 
+  def test_fetch_multi
+    group = IknowCache.register_group(:group, :id)
+    cache = group.register_cache(:store)
+
+    data = {
+      { id: 1 } => 'hello',
+      { id: 2 } => 'goodbye',
+    }
+
+    new_data = {
+      { id: 3 } => 'added',
+      { id: 4 } => 'extra',
+    }
+
+    all_data = data.merge(new_data)
+
+    cache.write_multi(data)
+
+    cache.fetch_multi(all_data.keys) do |missing_keys|
+      assert_equal(new_data.keys, missing_keys)
+      new_data
+    end
+
+    values = cache.read_multi(all_data.keys)
+    assert_equal(all_data, values)
+  end
+
+  def test_delete_multi
+    group = IknowCache.register_group(:group, :id)
+    cache = group.register_cache(:store)
+
+    data = {
+      { id: 1 } => 'hello',
+      { id: 2 } => 'goodbye',
+    }
+
+    cache.write_multi(data)
+    cache.delete_multi(data.keys)
+    values = cache.read_multi(data.keys)
+
+    assert_equal({}, values)
+  end
+
   def test_delete_from_group
     group = IknowCache.register_group(:group, :id)
     cache = group.register_cache(:store)

--- a/test/iknow_cache_test.rb
+++ b/test/iknow_cache_test.rb
@@ -36,6 +36,12 @@ class IknowCache::Test < MiniTest::Test
     assert_equal("#{@root}/group/1/1/10/store", cache.send(:path, cache.key.new(10)))
   end
 
+  def test_statically_versioned_cache_path
+    group = IknowCache.register_group(:group, :id)
+    cache = group.register_cache(:store, static_version: 100)
+    assert_equal("#{@root}/group/1/1/10/store/100", cache.send(:path, cache.key.new(10)))
+  end
+
   def test_null_key
     group = IknowCache.register_group(:group, :id)
     ex = assert_raises(ArgumentError) do

--- a/test/iknow_cache_test.rb
+++ b/test/iknow_cache_test.rb
@@ -68,7 +68,7 @@ class IknowCache::Test < MiniTest::Test
     childgroup.path(parentid: 10, childid: 1)
     childgroup.invalidate_cache_group(parentid: 10)
 
-    paths = childgroup.path_multi([{parentid: 10, childid: 20}, {parentid: 11, childid: 21}])
+    paths = childgroup.path_multi([{ parentid: 10, childid: 20 }, { parentid: 11, childid: 21 }])
 
     expected = {
       { parentid: 10, childid: 20 } => "#{@root}/parentgroup/1/1/10/childgroup/1/2/20",
@@ -99,7 +99,6 @@ class IknowCache::Test < MiniTest::Test
     assert_equal(expected, paths)
   end
 
-
   def test_invalidate_group
     group = IknowCache.register_group(:group, :id)
     assert_equal("#{@root}/group/1/1/10", group.path(id: 10))
@@ -116,7 +115,6 @@ class IknowCache::Test < MiniTest::Test
     assert_equal("#{@root}/parentgroup/5/1/11/childgroup/6/1/20", childgroup.path(parentid: 11, childid: 20))
   end
 
-
   def test_access
     group = IknowCache.register_group(:group, :id)
     cache = group.register_cache(:store)
@@ -124,25 +122,27 @@ class IknowCache::Test < MiniTest::Test
 
     assert_nil(cache.read(key))
 
-    cache.write(key, "hello")
+    cache.write(key, 'hello')
 
-    assert_equal("hello", cache.read(key))
+    assert_equal('hello', cache.read(key))
 
-    assert_equal("hello", cache.fetch(key){ "goodbye" })
+    assert_equal('hello', cache.fetch(key) { 'goodbye' })
 
     cache.delete(key)
 
     assert_nil(cache.read(key))
 
-    assert_equal("goodbye", cache.fetch(key){ "goodbye" })
+    assert_equal('goodbye', cache.fetch(key) { 'goodbye' })
   end
 
   def test_access_multi
     group = IknowCache.register_group(:group, :id)
     cache = group.register_cache(:store)
 
-    data = {{id: 1} => "hello",
-            {id: 2} => "goodbye"}
+    data = {
+      { id: 1 } => 'hello',
+      { id: 2 } => 'goodbye',
+    }
 
     cache.write_multi(data)
 
@@ -154,13 +154,13 @@ class IknowCache::Test < MiniTest::Test
     group = IknowCache.register_group(:group, :id)
     cache = group.register_cache(:store)
 
-    cache.write({id: 1}, "hello")
-    cache.write({id: 2}, "goodbye")
+    cache.write({ id: 1 }, 'hello')
+    cache.write({ id: 2 }, 'goodbye')
 
-    group.delete_all({id: 1})
+    group.delete_all({ id: 1 })
 
-    assert_nil(cache.read({id: 1}))
-    assert_equal("goodbye", cache.read({id: 2}))
+    assert_nil(cache.read({ id: 1 }))
+    assert_equal('goodbye', cache.read({ id: 2 }))
   end
 
   def test_double_configre


### PR DESCRIPTION
This allows individual caches that e.g. hold data for a particular viewmodel to be statically versioned by its schema version.

Also adds fetch_multi and delete_multi actions.